### PR TITLE
fix COPY route of binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ ENV PATH /root
 
 WORKDIR /root/
 
-COPY --from=builder /usr/app/go-graphql-api-boilerplate/go-graphql-api-boilerplate .
+COPY --from=builder /usr/app/go-graphql-api-boilerplate .
 
-COPY --from=builder /usr/app/go-graphql-api-boilerplate/migrate .
+COPY --from=builder /usr/app/migrate .
 
 EXPOSE 8080
 


### PR DESCRIPTION
- fix the wrong path to copy a binary from golang builder.