### PR TITLE
remove userID args in change_password & change_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ mutation {
 
 ```graphql
 mutation {
-  changePassword(userID: 1, password: "87654321") {
+  changePassword(password: "87654321") {
     ok
     error
     user {
@@ -167,7 +167,7 @@ mutation {
 
 ```graphql
 mutation {
-  changeProfile(userID: 1, bio: "Go developer", avatar: "go-developer.png") {
+  changeProfile(bio: "Go developer", avatar: "go-developer.png") {
     ok
     error
     user {

--- a/resolvers/change_password.go
+++ b/resolvers/change_password.go
@@ -30,7 +30,6 @@ func (r *Resolvers) ChangePassword(ctx context.Context, args changePasswordMutat
 }
 
 type changePasswordMutationArgs struct {
-	UserID   string
 	Password string
 }
 

--- a/resolvers/change_profile.go
+++ b/resolvers/change_profile.go
@@ -34,7 +34,6 @@ func (r *Resolvers) ChangeProfile(ctx context.Context, args changeProfileMutatio
 }
 
 type changeProfileMutationArgs struct {
-	UserID string
 	Bio    *string
 	Avatar *string
 }

--- a/schema/Mutation/mutation.graphql
+++ b/schema/Mutation/mutation.graphql
@@ -6,12 +6,8 @@ type Mutation {
     lastName: String!
   ): SignUpResponse!
   signIn(email: String!, password: String!): SignInResponse!
-  changePassword(userID: Int!, password: String!): ChangePasswordResponse!
-  changeProfile(
-    userID: Int!
-    bio: String
-    avatar: String
-  ): ChangeProfileResponse!
+  changePassword(password: String!): ChangePasswordResponse!
+  changeProfile(bio: String, avatar: String): ChangeProfileResponse!
 }
 type SignUpResponse {
   ok: Boolean!


### PR DESCRIPTION
`args.userID` is not required, because `userID` should be parsed from `Context`.

`args.userID` is removed from resolvers;
- Change Password
- Change Profile